### PR TITLE
ci: remove push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Remove `push` trigger from CI workflow to only run on pull requests
- Prevents redundant CI runs when PRs are merged to main

Closes #9

## Note

After merging this PR, please enable Branch Protection Rule for `main` branch:

1. Go to https://github.com/naitokosuke/vize-nix/settings/branches
2. Add rule for `main` branch:
   - [x] Require a pull request before merging
   - [x] Require status checks to pass before merging (select `build`)
   - [x] Do not allow bypassing the above settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)