### PR TITLE
docs: adopt new versioning scheme aligned with vize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Versioning Scheme
+
+This project uses the format: `<vize-version>-nix.<revision>`
+
+- When vize upstream updates: Update the vize version part
+- When vize-nix changes: Increment the `-nix.X` revision
 
 ## [Unreleased]
 
-## [0.0.2] - 2026-01-12
+## [0.0.1-alpha.31-nix.1] - 2026-01-13
 
 ### Changed
 
+- Adopt new versioning scheme aligned with vize upstream
 - Replace flake-utils with pure Nix implementation
 - Limit supported systems to aarch64-darwin only
+- Update vize to v0.0.1-alpha.31
 
 ### Removed
 
 - Remove flake-utils dependency
 
-## [0.0.1] - 2026-01-12
-
 ### Added
 
-- Initial Nix flake for vize v0.0.1-alpha.19
-- `packages.default` and `apps.default` outputs
-- Multi-platform support via flake-utils
+- CI workflow for build checks
+- Binary caching via Cachix with devenv
 
-[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/v0.0.2...HEAD
-[0.0.2]: https://github.com/naitokosuke/vize-nix/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/naitokosuke/vize-nix/releases/tag/v0.0.1
+[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/0.0.1-alpha.31-nix.1...HEAD
+[0.0.1-alpha.31-nix.1]: https://github.com/naitokosuke/vize-nix/releases/tag/0.0.1-alpha.31-nix.1


### PR DESCRIPTION
## Summary

- Adopt new versioning scheme: `<vize-version>-nix.<revision>`
- Update CHANGELOG.md with versioning rules and consolidated history
- Delete old tags (v0.0.1)

## Versioning Rules

| Event | Action |
|-------|--------|
| vize upstream update | Update vize version part |
| vize-nix specific change | Increment `-nix.X` |

## Remaining Tasks (after merge)

- [ ] Create initial tag `0.0.1-alpha.31-nix.1` on the merged commit

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)