### PR TITLE
ci: add automatic tag creation on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from CHANGELOG
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=## \[)[^\]]+(?=\])' CHANGELOG.md | head -1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Check if tag exists
+        id: check
+        if: steps.version.outputs.version != 'Unreleased'
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.version }}$"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.version.outputs.version != 'Unreleased' && steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}
+          echo "Created tag: ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically create git tags when PRs are merged to main
- Extracts version from CHANGELOG.md and creates tag if it doesn't exist

## How it works

1. Triggers on push to `main` (after PR merge)
2. Extracts the first version from CHANGELOG.md (skips `Unreleased`)
3. Checks if the tag already exists
4. Creates and pushes the tag if new

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)