### PR TITLE
chore: reduce vize update check frequency to 12 hours

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -2,8 +2,8 @@ name: Update vize version
 
 on:
   schedule:
-    # Check every hour
-    - cron: '0 * * * *'
+    # Check every 12 hours (at 00:00 and 12:00 UTC)
+    - cron: '0 0,12 * * *'
   workflow_dispatch: # Manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
- Change workflow schedule from hourly to every 12 hours (UTC 0:00 and 12:00)

## Reason
Reduce unnecessary CI runs and minimize failures from transient GitHub API errors (500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)