### PR TITLE
fix: add error handling to update-vize workflow

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Check if update is needed
         id: check
         run: |
+          set -e
           if [ "${{ steps.current.outputs.version }}" != "${{ steps.latest.outputs.version }}" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
             echo "Update needed: ${{ steps.current.outputs.version }} -> ${{ steps.latest.outputs.version }}"


### PR DESCRIPTION
## Summary
- Add `set -e` to fail fast on errors in shell scripts
- Add validation for `CURRENT_VERSION` extraction from flake.nix
- Add validation for `LATEST_VERSION` fetch from GitHub API
- Fix hash fetching: remove `2>/dev/null` that silently hides errors
- Fix hash fetching: use variable instead of fragile `xargs` pipe
- Add validation for `PREFETCH_HASH` and `NEW_HASH`

## Test plan
- [ ] Manually trigger workflow with `workflow_dispatch`
- [ ] Verify workflow fails gracefully when API is unavailable
- [ ] Verify error messages are visible in logs

Closes #19

---
Generated with [Claude Code](https://claude.ai/code)