### PR TITLE
fix: sort tags by semantic version instead of creation date

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -39,8 +39,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -e
-          # Use tags API instead of releases (vize doesn't use GitHub Releases)
-          LATEST_VERSION=$(gh api repos/ubugeeei/vize/tags --jq '.[0].name' | sed 's/^v//')
+          # Fetch all tags and sort by semantic version to get the latest
+          # (GitHub API returns tags by creation date, not version order)
+          LATEST_VERSION=$(gh api repos/ubugeeei/vize/tags --paginate --jq '.[].name' | sed 's/^v//' | sort -V | tail -1)
           if [ -z "$LATEST_VERSION" ]; then
             echo "Error: Could not fetch latest version from GitHub"
             exit 1


### PR DESCRIPTION
## Summary
- Fetch all tags with `--paginate` instead of relying on first result
- Sort tags by semantic version using `sort -V`
- Prevents downgrade PRs when hotfix tags for older versions are created

## Background
GitHub API returns tags ordered by creation date, not semantic version. If a hotfix tag (e.g., `v0.0.1-alpha.25.1`) is created after the latest version (`v0.0.1-alpha.31`), the workflow would incorrectly identify the hotfix as "latest".

## Test plan
- [ ] Verify `sort -V` correctly orders semantic versions
- [ ] Manually trigger workflow to confirm latest version detection

Closes #16

---
Generated with [Claude Code](https://claude.ai/code)