### PR TITLE
feat: add build verification step before creating PR

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -93,6 +93,14 @@ jobs:
         if: steps.check.outputs.needs_update == 'true'
         run: nix flake update
 
+      - name: Verify build
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          set -e
+          echo "Verifying build with updated flake.nix..."
+          nix build .#vize --no-link
+          echo "Build successful"
+
       - name: Create Pull Request
         if: steps.check.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Summary
- Add `nix build .#vize --no-link` step after updating flake.nix
- Verify build succeeds before creating pull request
- Prevents broken PRs from incorrect hashes or breaking changes

## Test plan
- [ ] Manually trigger workflow to verify build step runs
- [ ] Confirm PR is not created if build fails

Closes #20

---
Generated with [Claude Code](https://claude.ai/code)