### PR TITLE
fix: remove unnecessary nix flake update step

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -89,10 +89,6 @@ jobs:
 
           echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
 
-      - name: Update flake.lock
-        if: steps.check.outputs.needs_update == 'true'
-        run: nix flake update
-
       - name: Verify build
         if: steps.check.outputs.needs_update == 'true'
         run: |
@@ -116,7 +112,6 @@ jobs:
             ### Changes
             - Updated version in `flake.nix`
             - Updated source hash
-            - Updated `flake.lock`
 
             ### Links
             - Tag: https://github.com/ubugeeei/vize/tree/v${{ steps.latest.outputs.version }}


### PR DESCRIPTION
## Summary
- Remove `nix flake update` step that updates all flake inputs
- Remove `flake.lock` mention from PR body template

## Background
The vize source is fetched via `fetchFromGitHub`, not as a flake input. Running `nix flake update` updates all inputs (including nixpkgs), which:
- Pollutes the PR diff with unrelated changes
- May introduce unrelated build breakages
- Makes the PR harder to review

If nixpkgs updates are needed, they should be handled in a separate workflow/PR.

## Test plan
- [ ] Verify workflow still runs successfully without flake update step
- [ ] Confirm generated PR only contains vize-related changes

Closes #18

---
Generated with [Claude Code](https://claude.ai/code)