### PR TITLE
fix: limit sed replacement to first occurrence only

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -67,8 +67,8 @@ jobs:
           set -e
           NEW_VERSION="${{ steps.latest.outputs.version }}"
 
-          # Update version
-          sed -i "s/version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" flake.nix
+          # Update version (only first occurrence)
+          sed -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
 
           # Get new hash using nix-prefetch
           echo "Fetching hash for version $NEW_VERSION..."
@@ -84,8 +84,8 @@ jobs:
           fi
           echo "Got hash: $NEW_HASH"
 
-          # Update hash
-          sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$NEW_HASH\"|" flake.nix
+          # Update hash (only first occurrence)
+          sed -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
 
           echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
 


### PR DESCRIPTION
## Summary
- Use GNU sed address range syntax `0,/pattern/s//` to replace only the first match
- Update comments to clarify the behavior

## Background
The previous sed commands would replace all matching lines in the file. While the current `flake.nix` has only one `version` and `hash`, this is a defensive fix to prevent unintended replacements if the file structure changes.

This also resolves the inconsistency where `head -1` was used to extract the first version, but replacement affected all lines.

## Test plan
- [ ] Verify sed correctly replaces only first occurrence
- [ ] Test with a file containing multiple version/hash patterns

Closes #17

---
Generated with [Claude Code](https://claude.ai/code)