### PR TITLE
style: unify token reference to github.token

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -101,7 +101,7 @@ jobs:
         if: steps.check.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           commit-message: "feat: update vize to v${{ steps.latest.outputs.version }}"
           title: "feat: update vize to v${{ steps.latest.outputs.version }}"
           body: |


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with `github.token` for consistency

## Background
The workflow used two different ways to reference the same token:
- Line 39: `${{ github.token }}`
- Line 104: `${{ secrets.GITHUB_TOKEN }}`

Both are functionally equivalent, but using a single style improves code readability.

## Test plan
- [ ] Verify workflow still has proper permissions after change

Closes #21

---
Generated with [Claude Code](https://claude.ai/code)