### PR TITLE
perf: enable Cachix cache in update-vize.yml

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -17,9 +17,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
         with:
-          nix_path: nixpkgs=channel:nixpkgs-unstable
+          name: vize-nix
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Get current version
         id: current


### PR DESCRIPTION
## Summary

- Add `cachix/cachix-action` to `update-vize.yml` to enable binary cache during build verification
- Update `install-nix-action` from v27 to v31 for consistency with `ci.yml`

## Expected Benefits

- Faster build verification step in update-vize workflow
- Reduced CI execution time
- Consistent Nix installer version across all workflows

Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)