### PR TITLE
feat: leverage devenv in CI to unify with local environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,15 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v16
-        with:
-          name: vize-nix
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
 
       - name: Build vize
-        run: nix build .#vize --print-build-logs
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: devenv shell -- build
 
       - name: Test vize runs
-        run: nix run .#vize -- --version
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: devenv shell -- test

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,7 @@
 {
   cachix.pull = [ "vize-nix" ];
   cachix.push = "vize-nix";
+
+  scripts.build.exec = "nix build .#vize --print-build-logs";
+  scripts.test.exec = "nix run .#vize -- --version";
 }


### PR DESCRIPTION
## Summary

- Add `build` and `test` scripts to `devenv.nix`
- Replace `cachix-action` with devenv's built-in cachix configuration
- Use `devenv shell -- <script>` to run CI commands

## Changes

### devenv.nix
```nix
{
  cachix.pull = [ "vize-nix" ];
  cachix.push = "vize-nix";

  scripts.build.exec = "nix build .#vize --print-build-logs";
  scripts.test.exec = "nix run .#vize -- --version";
}
```

### ci.yml
- Removed `cachix-action` (devenv handles Cachix configuration)
- Run `devenv shell -- build` and `devenv shell -- test`

## Benefits

- **Single Source of Truth**: Cachix and build/test configuration centralized in `devenv.nix`
- **Local/CI Consistency**: Same commands work locally and in CI
- **Simplified Onboarding**: New developers use `devenv shell` to get started

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)