### PR TITLE
perf: add Magic Nix Cache to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
 

--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
       - name: Setup Cachix
         uses: cachix/cachix-action@v16
         with:


### PR DESCRIPTION
## Summary

Add `DeterminateSystems/magic-nix-cache-action` to both `ci.yml` and `update-vize.yml` to leverage GitHub Actions cache alongside Cachix.

## Changes

- Added Magic Nix Cache step after Nix installation in both workflows

## Benefits

- **Free additional caching**: Uses GitHub Actions cache (up to 10GB per repository)
- **Zero configuration**: No tokens or authentication setup required
- **Automatic**: Automatically caches and restores build artifacts
- **Non-intrusive**: Works alongside existing Cachix setup without conflicts

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)