### PR TITLE
fix: replace Magic Nix Cache with Cachix in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: vize-nix
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Install devenv
         run: nix profile install nixpkgs#devenv

--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: Setup Cachix
         uses: cachix/cachix-action@v16
         with:


### PR DESCRIPTION
## Summary

- Remove Magic Nix Cache from `update-vize.yml`
- Replace Magic Nix Cache with Cachix in `ci.yml`

## Rationale

Issue #38 concluded that Cachix should be the single caching solution because:

- `devenv.nix` uses Cachix for local development
- Cachix provides shared cache for external users
- Single caching system is simpler to maintain

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, manually trigger update-vize workflow (#41)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)