### PR TITLE
perf: skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+      - ".gitignore"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Add `paths-ignore` filter to CI workflow to skip builds for documentation-only changes

Closes #44

## Decision: `paths-ignore` vs `paths`

We chose `paths-ignore` over `paths` for the following reasons:

| Aspect | `paths-ignore` | `paths` |
|--------|---------------|---------|
| Behavior | CI runs except for specified files | CI runs only for specified files |
| New file addition | CI runs automatically | Must update list or CI won't run |
| Safety | Higher (less likely to miss) | Lower (risk of forgetting to add) |

**Rationale:** Using `paths-ignore` is safer because when new code files (e.g., scripts, config files) are added in the future, CI will automatically run without requiring workflow updates. With `paths`, there's a risk of merging code changes without CI validation if someone forgets to update the paths list.

## Test plan

- [ ] Verify CI skips on documentation-only PRs
- [ ] Verify CI runs on `.nix` file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)