### PR TITLE
fix: use macos-latest for update-vize workflow

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-update:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest # aarch64-darwin
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- The `update-vize.yml` workflow ran on `ubuntu-latest` (x86_64-linux), but `flake.nix` only supports `aarch64-darwin`, causing `nix build .#vize` to fail
- Change the runner to `macos-latest` to match the supported system, consistent with `ci.yml`

## Test plan
- [ ] Verify the `update-vize.yml` workflow no longer fails at the "Verify build" step

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)