### PR TITLE
fix: use GNU sed via Nix for macOS compatibility in update-vize workflow

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -71,8 +71,11 @@ jobs:
           set -e
           NEW_VERSION="${{ steps.latest.outputs.version }}"
 
+          # Use GNU sed via Nix for compatibility with macOS
+          GSED="nix run nixpkgs#gnused --"
+
           # Update version (only first occurrence)
-          sed -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
+          $GSED -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
 
           # Get new hash using nix-prefetch
           echo "Fetching hash for version $NEW_VERSION..."
@@ -89,7 +92,7 @@ jobs:
           echo "Got hash: $NEW_HASH"
 
           # Update hash (only first occurrence)
-          sed -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
+          $GSED -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
 
           echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
 


### PR DESCRIPTION
## Summary
- BSD sed on macOS does not support `sed -i` without an extension argument or the `0,/pattern/` GNU extension
- Use GNU sed via `nix run nixpkgs#gnused` to keep existing sed commands working on the macOS runner

## Test plan
- [ ] Manually trigger the `update-vize.yml` workflow and verify the "Update flake.nix" step succeeds

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)