### PR TITLE
fix: use PAT for automated PR creation to trigger CI

### DIFF
--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -108,7 +108,7 @@ jobs:
         if: steps.check.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.VIZE_NIX_PR_TOKEN }}
           commit-message: "feat: update vize to v${{ steps.latest.outputs.version }}"
           title: "feat: update vize to v${{ steps.latest.outputs.version }}"
           body: |


### PR DESCRIPTION
## Summary
- Replace `github.token` with `VIZE_NIX_PR_TOKEN` (PAT) in `peter-evans/create-pull-request`
- PRs created with `github.token` don't trigger other workflows (GitHub's infinite loop prevention)
- Using a PAT allows CI to be automatically triggered on auto-created PRs

Closes #54

## Test plan
- [ ] CI passes on this PR
- [ ] Next scheduled `Update vize version` run creates a PR that auto-triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)