### PR TITLE
feat: add CHANGELOG.md update to automated vize version updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ jobs:
       - name: Extract version from CHANGELOG
         id: version
         run: |
-          VERSION=$(grep -oP '(?<=## \[)[^\]]+(?=\])' CHANGELOG.md | head -1)
+          VERSION=$(grep -oP '(?<=## \[)[^\]]+(?=\])' CHANGELOG.md | grep -v '^Unreleased$' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "No release version found in CHANGELOG.md"
+            VERSION="Unreleased"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 

--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -96,6 +96,36 @@ jobs:
 
           echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
 
+      - name: Update CHANGELOG.md
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          set -e
+          NEW_VERSION="${{ steps.latest.outputs.version }}"
+          NEW_TAG_VERSION="${NEW_VERSION}-nix.1"
+          TODAY=$(date +%Y-%m-%d)
+
+          # Use GNU sed via Nix for compatibility with macOS
+          GSED="nix run nixpkgs#gnused --"
+
+          # Get previous release version from CHANGELOG (skip Unreleased)
+          PREV_TAG_VERSION=$($GSED -n 's/^## \[\([^]]*\)\].*/\1/p' CHANGELOG.md | grep -v '^Unreleased$' | head -1)
+
+          # Insert new version section after ## [Unreleased]
+          $GSED -i "/^## \[Unreleased\]/a\\\\n## [${NEW_TAG_VERSION}] - ${TODAY}\\n\\n### Changed\\n\\n- Update vize to v${NEW_VERSION}" CHANGELOG.md
+
+          # Update [Unreleased] compare link
+          $GSED -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/${NEW_TAG_VERSION}...HEAD|" CHANGELOG.md
+
+          # Add new version compare link before the previous version link
+          if [ -n "$PREV_TAG_VERSION" ]; then
+            $GSED -i "/^\[${PREV_TAG_VERSION}\]/i [${NEW_TAG_VERSION}]: https://github.com/naitokosuke/vize-nix/compare/${PREV_TAG_VERSION}...${NEW_TAG_VERSION}" CHANGELOG.md
+          else
+            # No previous version - add link at the end
+            echo "[${NEW_TAG_VERSION}]: https://github.com/naitokosuke/vize-nix/releases/tag/${NEW_TAG_VERSION}" >> CHANGELOG.md
+          fi
+
+          echo "Updated CHANGELOG.md with version ${NEW_TAG_VERSION}"
+
       - name: Verify build
         if: steps.check.outputs.needs_update == 'true'
         run: |
@@ -119,6 +149,7 @@ jobs:
             ### Changes
             - Updated version in `flake.nix`
             - Updated source hash
+            - Updated `CHANGELOG.md`
 
             ### Links
             - Tag: https://github.com/ubugeeei/vize/tree/v${{ steps.latest.outputs.version }}


### PR DESCRIPTION
## Summary
- Fix version extraction in `release.yml` to skip `Unreleased` entry
- Add CHANGELOG.md update step to `update-vize.yml` using GNU sed via Nix

Closes #58

## Test plan
- [ ] CI passes
- [ ] Manual trigger of `update-vize.yml` correctly updates CHANGELOG.md
- [ ] After merge, `release.yml` creates a tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)