### PR TITLE
fix: pin Rust toolchain via rust-overlay (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project uses the format: `<vize-version>-nix.<revision>`
 
 ## [Unreleased]
 
+### Changed
+
+* Pin Rust toolchain via `rust-overlay` to decouple rustc from `nixpkgs-unstable` and avoid version skew when vize adopts newer rustc releases (#95)
+
 ## [0.49.0-nix.1] - 2026-04-21
 
 ### Changed

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777000482,
+        "narHash": "sha256-CZ5FKUSA8FCJf0h9GWdPJXoVVDL9H5yC74GkVc5ubIM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "403c09094a877e6c4816462d00b1a56ff8198e06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,14 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { self, nixpkgs }:
+    { self, nixpkgs, rust-overlay }:
     let
       supportedSystems = [
         "aarch64-darwin"
@@ -14,46 +18,59 @@
 
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      mkVize = pkgs: pkgs.rustPlatform.buildRustPackage rec {
-        pname = "vize";
-        version = "0.49.0";
+      pkgsFor = system: import nixpkgs {
+        inherit system;
+        overlays = [ (import rust-overlay) ];
+      };
 
-        src = pkgs.fetchFromGitHub {
-          owner = "ubugeeei";
-          repo = "vize";
-          rev = "v${version}";
-          hash = "sha256-DPnHmVrFn9b7dHb3HSgFFmFKH/6D8yfHbxUeYdIcW8E=";
-        };
+      mkVize = pkgs:
+        let
+          rustToolchain = pkgs.rust-bin.stable.latest.default;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
+        in
+        rustPlatform.buildRustPackage rec {
+          pname = "vize";
+          version = "0.49.0";
 
-        cargoLock = {
-          lockFile = "${src}/Cargo.lock";
-outputHashes = {
-            "oxc_allocator-0.116.0" = "sha256-xnJ+lZwZh/F7KLebJcgPvPrAQrnlwQx9ldSJrljxnYs=";
+          src = pkgs.fetchFromGitHub {
+            owner = "ubugeeei";
+            repo = "vize";
+            rev = "v${version}";
+            hash = "sha256-DPnHmVrFn9b7dHb3HSgFFmFKH/6D8yfHbxUeYdIcW8E=";
+          };
+
+          cargoLock = {
+            lockFile = "${src}/Cargo.lock";
+            outputHashes = {
+              "oxc_allocator-0.116.0" = "sha256-xnJ+lZwZh/F7KLebJcgPvPrAQrnlwQx9ldSJrljxnYs=";
+            };
+          };
+
+          cargoBuildFlags = [
+            "-p"
+            "vize"
+          ];
+
+          # Skip tests during build: upstream test_backend_size requires a TTY
+          # which is unavailable in Nix sandbox / CI environments
+          doCheck = false;
+
+          meta = {
+            description = "High-performance Vue.js toolchain in Rust";
+            homepage = "https://github.com/ubugeeei/vize";
+            license = pkgs.lib.licenses.mit;
+            maintainers = [ ];
+            mainProgram = "vize";
           };
         };
-
-        cargoBuildFlags = [
-          "-p"
-          "vize"
-        ];
-
-        # Skip tests during build: upstream test_backend_size requires a TTY
-        # which is unavailable in Nix sandbox / CI environments
-        doCheck = false;
-
-        meta = {
-          description = "High-performance Vue.js toolchain in Rust";
-          homepage = "https://github.com/ubugeeei/vize";
-          license = pkgs.lib.licenses.mit;
-          maintainers = [ ];
-          mainProgram = "vize";
-        };
-      };
     in
     {
       packages = forAllSystems (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = pkgsFor system;
           vize = mkVize pkgs;
         in
         {
@@ -64,7 +81,7 @@ outputHashes = {
 
       apps = forAllSystems (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = pkgsFor system;
           vize = mkVize pkgs;
           app = {
             type = "app";


### PR DESCRIPTION
## Summary

* Introduce `oxalica/rust-overlay` and use the latest stable Rust toolchain via `makeRustPlatform` instead of relying on `nixpkgs-unstable` rustc
* Fixes scheduled `Update vize version` workflow failing when upstream vize adopts a rustc newer than what `nixpkgs-unstable` currently ships (e.g. vize 0.56.0 requiring rustc 1.93 while nixpkgs shipped 1.91.1)

Closes #95

## Test plan

- [x] `nix build .#vize` on `aarch64-darwin` with rust-overlay's rustc 1.95.0
- [x] `nix run .#vize -- --version` → `vize 0.49.0`
- [ ] Next scheduled `Update vize version` run succeeds against latest upstream vize

🤖 Generated with [Claude Code](https://claude.com/claude-code)