### PR TITLE
refactor: switch flake to upstream prebuilt binaries instead of building from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
   build:
     needs: changes
     if: needs.changes.outputs.needs_build == 'true'
-    runs-on: macos-latest # aarch64-darwin
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768178648,
-        "narHash": "sha256-kz/F6mhESPvU1diB7tOM3nLcBfQe7GU7GQCymRlTi/s=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3fbab70c6e69c87ea2b6e48aa6629da2aa6a23b0",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -18,28 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777000482,
-        "narHash": "sha256-CZ5FKUSA8FCJf0h9GWdPJXoVVDL9H5yC74GkVc5ubIM=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "403c09094a877e6c4816462d00b1a56ff8198e06",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,60 +3,56 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
-    { self, nixpkgs, rust-overlay }:
+    { self, nixpkgs }:
     let
-      supportedSystems = [
-        "aarch64-darwin"
-      ];
+      version = "0.241.0";
 
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-
-      pkgsFor = system: import nixpkgs {
-        inherit system;
-        overlays = [ (import rust-overlay) ];
+      sources = {
+        "aarch64-darwin" = {
+          asset = "vize-aarch64-apple-darwin.tar.gz";
+          hash = "sha256-C0SNhi47Q8EnVoaskE8sUQ0WnpJfAPnMFaGnhwQaKaY=";
+        };
+        "aarch64-linux" = {
+          asset = "vize-aarch64-unknown-linux-gnu.tar.gz";
+          hash = "sha256-2BCFoQQu95jmMMdUCfVZ/+QHV6VPreCqbV9WmTYI0jk=";
+        };
+        "x86_64-linux" = {
+          asset = "vize-x86_64-unknown-linux-gnu.tar.gz";
+          hash = "sha256-VaF2gbhR/+zqeh7pkkg7IUSDEzMp7bkm+I0bbZdExyg=";
+        };
       };
 
-      mkVize = pkgs:
+      supportedSystems = builtins.attrNames sources;
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      mkVize = system:
         let
-          rustToolchain = pkgs.rust-bin.stable.latest.default;
-          rustPlatform = pkgs.makeRustPlatform {
-            cargo = rustToolchain;
-            rustc = rustToolchain;
-          };
+          pkgs = nixpkgs.legacyPackages.${system};
+          src = sources.${system};
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
         in
-        rustPlatform.buildRustPackage rec {
+        pkgs.stdenv.mkDerivation {
           pname = "vize";
-          version = "0.241.0";
+          inherit version;
 
-          src = pkgs.fetchFromGitHub {
-            owner = "ubugeeei";
-            repo = "vize";
-            rev = "v${version}";
-            hash = "sha256-fZDBbRYckop/a5j8u1832GhiXFECHOcDMp6yOyPt+gs=";
+          src = pkgs.fetchurl {
+            url = "https://github.com/ubugeeei-prod/vize/releases/download/v${version}/${src.asset}";
+            hash = src.hash;
           };
 
-          cargoLock = {
-            lockFile = "${src}/Cargo.lock";
-outputHashes = {
-            "oxc_allocator-0.127.0" = "sha256-At39BxG7xeI9niqHpU2jCwVI77NcQ/SeseXSLUQVWO8=";
-          };
-          };
+          sourceRoot = ".";
 
-          cargoBuildFlags = [
-            "-p"
-            "vize"
-          ];
+          nativeBuildInputs = pkgs.lib.optional isLinux pkgs.autoPatchelfHook;
+          buildInputs = pkgs.lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
 
-          # Skip tests during build: upstream test_backend_size requires a TTY
-          # which is unavailable in Nix sandbox / CI environments
-          doCheck = false;
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 vize $out/bin/vize
+            runHook postInstall
+          '';
 
           meta = {
             description = "High-performance Vue.js toolchain in Rust";
@@ -64,15 +60,14 @@ outputHashes = {
             license = pkgs.lib.licenses.mit;
             maintainers = [ ];
             mainProgram = "vize";
+            platforms = supportedSystems;
+            sourceProvenance = with pkgs.lib.sourceTypes; [ binaryNativeCode ];
           };
         };
     in
     {
       packages = forAllSystems (system:
-        let
-          pkgs = pkgsFor system;
-          vize = mkVize pkgs;
-        in
+        let vize = mkVize system; in
         {
           inherit vize;
           default = vize;
@@ -81,8 +76,7 @@ outputHashes = {
 
       apps = forAllSystems (system:
         let
-          pkgs = pkgsFor system;
-          vize = mkVize pkgs;
+          vize = mkVize system;
           app = {
             type = "app";
             program = "${vize}/bin/vize";


### PR DESCRIPTION
Closes #165.

## Summary

* Replace the source build (`rust-overlay` + `rustPlatform.buildRustPackage`) with a binary install that fetches platform-appropriate tarballs from `ubugeeei-prod/vize` releases.
* Drop the `rust-overlay` input, `cargoLock` / `outputHashes`, and `doCheck = false`.
* Expand `supportedSystems` from `aarch64-darwin` only to `aarch64-darwin`, `aarch64-linux`, `x86_64-linux` (upstream does not ship `x86_64-apple-darwin`).
* On Linux, `autoPatchelfHook` patches the dynamically-linked binary for NixOS.

## Why

The source build has been a recurring pain point: rustc skew (#95), per-release `outputHashes` for `oxc_allocator` (#69), TTY-requiring upstream tests (#50), Linux-only crates breaking on macOS (#52), missing platform support (#46). Switching to upstream binaries eliminates all of these failure modes and reduces version bumps to swapping SHA256 hashes.

## Verification

```
nix build .#vize          # OK
./result/bin/vize --version  # vize 0.241.0
nix flake check --all-systems --no-build  # all 3 systems eval cleanly
nix run .#vize -- --version  # vize 0.241.0
```

## Out of scope (follow-ups)

* **`.github/workflows/update-vize.yml` will break on its next scheduled run.** It currently sed-updates a single source hash and manages `outputHashes` for git deps in `Cargo.lock`. After this PR lands, it needs to instead fetch and hash 3 platform tarballs per release. Tracked separately — consider disabling the cron until the follow-up lands.
* `release.yml` and `ci.yml` are unaffected.