### PR TITLE
refactor: simplify flake to aarch64-darwin with sources.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,38 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      needs_build: ${{ steps.filter.outputs.needs_build }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for build-relevant changes
-        id: filter
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          # Check if any non-doc files changed
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -vcE '\.(md)$|^LICENSE$|^\.gitignore$' || true)
-          if [ "$CHANGED" -gt 0 ]; then
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          else
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "Only documentation changes, skipping build"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  build:
-    needs: changes
-    if: needs.changes.outputs.needs_build == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  # required status check (main-protection ruleset)
+  ci-complete:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -50,21 +21,8 @@ jobs:
           name: vize-nix
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build vize
-        run: nix build .#vize --print-build-logs
+      - name: Flake check
+        run: nix flake check --print-build-logs
 
       - name: Test vize runs
-        run: nix run .#vize -- --version
-
-  ci-complete:
-    runs-on: ubuntu-latest
-    needs: [build]
-    if: always()
-    steps:
-      - name: Check build result
-        run: |
-          if [[ "${{ needs.build.result }}" == "failure" ]]; then
-            echo "Build failed"
-            exit 1
-          fi
-          echo "CI complete (build: ${{ needs.build.result }})"
+        run: nix run . -- --version

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,27 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          token: ${{ secrets.VIZE_NIX_PR_TOKEN }}
+          pr-title: 'chore: update flake.lock'
+          pr-labels: |
+            dependencies
+            automated

--- a/.github/workflows/update-vize.yml
+++ b/.github/workflows/update-vize.yml
@@ -2,13 +2,12 @@ name: Update vize version
 
 on:
   schedule:
-    # Check every 12 hours (at 00:00 and 12:00 UTC)
     - cron: '0 0,12 * * *'
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch:
 
 jobs:
-  check-update:
-    runs-on: macos-latest # aarch64-darwin
+  update:
+    runs-on: macos-latest
     permissions:
       contents: write
       pull-requests: write
@@ -25,145 +24,90 @@ jobs:
           name: vize-nix
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Get current version
-        id: current
-        run: |
-          set -e
-          CURRENT_VERSION=$(grep 'version = "' flake.nix | head -1 | sed 's/.*version = "\([^"]*\)".*/\1/')
-          if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not extract current version from flake.nix"
-            exit 1
-          fi
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "Current version: $CURRENT_VERSION"
-
-      - name: Get latest release from upstream
-        id: latest
+      - name: Get versions
+        id: versions
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -e
-          # We track binary releases from ubugeeei-prod/vize (where the
-          # prebuilt artifacts our flake depends on are published).
-          LATEST_VERSION=$(gh api repos/ubugeeei-prod/vize/releases/latest --jq '.tag_name | sub("^v"; "")')
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "Error: Could not fetch latest release from ubugeeei-prod/vize"
-            exit 1
-          fi
-          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest version: $LATEST_VERSION"
+          set -euo pipefail
+          CURRENT=$(jq -er '.version' sources.json)
+          # binary releases live on ubugeeei-prod/vize, not ubugeeei/vize
+          LATEST=$(gh api repos/ubugeeei-prod/vize/releases/latest --jq '.tag_name | sub("^v"; "")')
+          [ -n "$LATEST" ]
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Current: $CURRENT / Latest: $LATEST"
 
-      - name: Check if update is needed
-        id: check
+      - name: Update sources.json
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
         run: |
-          set -e
-          if [ "${{ steps.current.outputs.version }}" != "${{ steps.latest.outputs.version }}" ]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "Update needed: ${{ steps.current.outputs.version }} -> ${{ steps.latest.outputs.version }}"
-          else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "Already up to date"
-          fi
+          set -euo pipefail
+          NEW_VERSION="${{ steps.versions.outputs.latest }}"
 
-      - name: Update flake.nix
-        if: steps.check.outputs.needs_update == 'true'
-        run: |
-          set -e
-          NEW_VERSION="${{ steps.latest.outputs.version }}"
+          jq --arg version "$NEW_VERSION" '.version = $version' sources.json > sources.json.tmp
+          mv sources.json.tmp sources.json
 
-          # Use GNU sed via Nix for compatibility with macOS
-          GSED="nix run nixpkgs#gnused --"
-
-          # Update version (only first occurrence)
-          $GSED -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
-
-          # Update per-platform release-asset hashes.
-          # Each entry: rust-target (used in asset filename) | nix system (informational)
-          PLATFORMS="aarch64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu"
-          for TARGET in $PLATFORMS; do
-            ASSET="vize-${TARGET}.tar.gz"
+          for SYSTEM in $(jq -r '.sources | keys[]' sources.json); do
+            ASSET=$(jq -er --arg system "$SYSTEM" '.sources[$system].asset' sources.json)
             URL="https://github.com/ubugeeei-prod/vize/releases/download/v${NEW_VERSION}/${ASSET}"
             echo "Prefetching ${ASSET}..."
-            PREFETCH_HASH=$(nix-prefetch-url "$URL")
-            if [ -z "$PREFETCH_HASH" ]; then
-              echo "Error: Failed to prefetch $ASSET"
-              exit 1
-            fi
-            SRI_HASH=$(nix hash to-sri --type sha256 "$PREFETCH_HASH")
-            if [ -z "$SRI_HASH" ]; then
-              echo "Error: Failed to convert hash to SRI format for $ASSET"
-              exit 1
-            fi
-            echo "Got hash for $ASSET: $SRI_HASH"
-            # Range-sed: from the asset line until the next hash line within the
-            # same attrset, replace the SRI hash.
-            $GSED -i "/asset = \"${ASSET}\";/,/hash = / { s|hash = \"sha256-[^\"]*\"|hash = \"${SRI_HASH}\"|; }" flake.nix
+            HASH=$(nix store prefetch-file --json "$URL" | jq -er '.hash')
+            jq --arg system "$SYSTEM" --arg hash "$HASH" \
+              '.sources[$system].hash = $hash' sources.json > sources.json.tmp
+            mv sources.json.tmp sources.json
           done
 
-          echo "Updated flake.nix to version $NEW_VERSION"
-
       - name: Update CHANGELOG.md
-        if: steps.check.outputs.needs_update == 'true'
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
         run: |
-          set -e
-          NEW_VERSION="${{ steps.latest.outputs.version }}"
-          NEW_TAG_VERSION="${NEW_VERSION}-nix.1"
+          set -euo pipefail
+          NEW_VERSION="${{ steps.versions.outputs.latest }}"
+          NEW_TAG="${NEW_VERSION}-nix.1"
           TODAY=$(date +%Y-%m-%d)
+          PREV_TAG=$(awk -F'[][]' '/^## \[/ && $2 != "Unreleased" { print $2; exit }' CHANGELOG.md)
 
-          # Use GNU sed via Nix for compatibility with macOS
-          GSED="nix run nixpkgs#gnused --"
-
-          # Get previous release version from CHANGELOG (skip Unreleased)
-          PREV_TAG_VERSION=$($GSED -n 's/^## \[\([^]]*\)\].*/\1/p' CHANGELOG.md | grep -v '^Unreleased$' | head -1)
-
-          # Insert new version section after ## [Unreleased]
-          $GSED -i "/^## \[Unreleased\]/a\\\\n## [${NEW_TAG_VERSION}] - ${TODAY}\\n\\n### Changed\\n\\n- Update vize to v${NEW_VERSION}" CHANGELOG.md
-
-          # Update [Unreleased] compare link
-          $GSED -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/${NEW_TAG_VERSION}...HEAD|" CHANGELOG.md
-
-          # Add new version compare link before the previous version link
-          if [ -n "$PREV_TAG_VERSION" ]; then
-            $GSED -i "/^\[${PREV_TAG_VERSION}\]/i [${NEW_TAG_VERSION}]: https://github.com/naitokosuke/vize-nix/compare/${PREV_TAG_VERSION}...${NEW_TAG_VERSION}" CHANGELOG.md
-          else
-            # No previous version - add link at the end
-            echo "[${NEW_TAG_VERSION}]: https://github.com/naitokosuke/vize-nix/releases/tag/${NEW_TAG_VERSION}" >> CHANGELOG.md
-          fi
-
-          echo "Updated CHANGELOG.md with version ${NEW_TAG_VERSION}"
+          awk -v new_tag="$NEW_TAG" -v prev_tag="$PREV_TAG" -v today="$TODAY" -v upstream="$NEW_VERSION" '
+            /^## \[Unreleased\]$/ {
+              print
+              print ""
+              print "## [" new_tag "] - " today
+              print ""
+              print "### Changed"
+              print ""
+              print "- Update vize to v" upstream
+              next
+            }
+            /^\[Unreleased\]: / {
+              print "[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/" new_tag "...HEAD"
+              print "[" new_tag "]: https://github.com/naitokosuke/vize-nix/compare/" prev_tag "..." new_tag
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.tmp
+          mv CHANGELOG.md.tmp CHANGELOG.md
 
       - name: Verify build
-        if: steps.check.outputs.needs_update == 'true'
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
         run: |
-          set -e
-          echo "Verifying build with updated flake.nix..."
-          nix build .#vize --no-link
-          echo "Build successful"
+          set -euo pipefail
+          nix flake check --print-build-logs
+          nix run . -- --version
 
       - name: Create Pull Request
-        if: steps.check.outputs.needs_update == 'true'
-        uses: peter-evans/create-pull-request@v6
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.VIZE_NIX_PR_TOKEN }}
-          commit-message: "feat: update vize to v${{ steps.latest.outputs.version }}"
-          title: "feat: update vize to v${{ steps.latest.outputs.version }}"
+          commit-message: 'feat: update vize to v${{ steps.versions.outputs.latest }}'
+          title: 'feat: update vize to v${{ steps.versions.outputs.latest }}'
           body: |
-            ## 🚀 vize version update
+            Updates vize from `v${{ steps.versions.outputs.current }}` to `v${{ steps.versions.outputs.latest }}`.
 
-            Updates vize from `v${{ steps.current.outputs.version }}` to `v${{ steps.latest.outputs.version }}`
+            - Release: https://github.com/ubugeeei-prod/vize/releases/tag/v${{ steps.versions.outputs.latest }}
+            - Compare: https://github.com/ubugeeei/vize/compare/v${{ steps.versions.outputs.current }}...v${{ steps.versions.outputs.latest }}
 
-            ### Changes
-            - Updated version in `flake.nix`
-            - Updated per-platform release-asset hashes (aarch64-darwin, aarch64-linux, x86_64-linux)
-            - Updated `CHANGELOG.md`
-
-            ### Links
-            - Release: https://github.com/ubugeeei-prod/vize/releases/tag/v${{ steps.latest.outputs.version }}
-            - Compare: https://github.com/ubugeeei/vize/compare/v${{ steps.current.outputs.version }}...v${{ steps.latest.outputs.version }}
-
-            ---
             🤖 This PR was automatically created by GitHub Actions
-          branch: update-vize-${{ steps.latest.outputs.version }}
+          branch: update-vize
           delete-branch: true
           labels: |
             dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ This project uses the format: `<vize-version>-nix.<revision>`
 
 ## [Unreleased]
 
+## [0.276.0-nix.2] - 2026-07-04
+
+### Changed
+
+- Move version and per-platform hashes from `flake.nix` to `sources.json`; the update workflow now edits JSON with `jq` instead of `sed` on Nix code
+- Use a fixed `update-vize` branch for update PRs so a newer release supersedes an unmerged one
+- Simplify CI to a single macOS job
+
+### Added
+
+- `overlays.default` and `checks` flake outputs
+- Install-time `--version` smoke check via `versionCheckHook`
+- Weekly scheduled `flake.lock` update workflow
+
+### Removed
+
+- Linux support (`aarch64-linux`, `x86_64-linux`); this flake now targets `aarch64-darwin` only
+- `apps` flake output (`nix run` falls back to `packages.default`)
+
 ## [0.276.0-nix.1] - 2026-07-04
 
 ### Changed
@@ -621,7 +640,8 @@ This project uses the format: `<vize-version>-nix.<revision>`
 - CI workflow for build checks
 - Binary caching via Cachix with devenv
 
-[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/0.276.0-nix.1...HEAD
+[Unreleased]: https://github.com/naitokosuke/vize-nix/compare/0.276.0-nix.2...HEAD
+[0.276.0-nix.2]: https://github.com/naitokosuke/vize-nix/compare/0.276.0-nix.1...0.276.0-nix.2
 [0.276.0-nix.1]: https://github.com/naitokosuke/vize-nix/compare/0.272.1-nix.1...0.276.0-nix.1
 [0.272.1-nix.1]: https://github.com/naitokosuke/vize-nix/compare/0.271.0-nix.1...0.272.1-nix.1
 [0.271.0-nix.1]: https://github.com/naitokosuke/vize-nix/compare/0.268.0-nix.1...0.271.0-nix.1

--- a/README.md
+++ b/README.md
@@ -2,10 +2,54 @@
 
 Unofficial Nix flake for [Vize](https://github.com/ubugeeei/vize) (personal use).
 
+This flake repackages the official prebuilt binaries from [GitHub Releases](https://github.com/ubugeeei-prod/vize/releases), so installation takes seconds with no Rust toolchain or source build.
+
 ## What is Vize?
 
 Vize is a high-performance Vue.js toolchain written in Rust. It provides compilation, linting, formatting, and type checking for Vue Single File Components.
 
+## Supported systems
+
+- `aarch64-darwin` (Apple Silicon macOS)
+
+Other platforms can be added by extending [`sources.json`](./sources.json).
+
+## Usage
+
+Run without installing:
+
+```sh
+nix run github:naitokosuke/vize-nix -- --help
+```
+
+Install into your profile:
+
+```sh
+nix profile install github:naitokosuke/vize-nix
+```
+
+Use as a flake input:
+
+```nix
+{
+  inputs.vize-nix.url = "github:naitokosuke/vize-nix";
+
+  # then e.g. inputs.vize-nix.packages.${system}.default
+}
+```
+
+`overlays.default` is also available and adds `pkgs.vize`.
+
+## Versioning
+
+Tags follow `<vize-version>-nix.<revision>`
+
+- the vize part tracks the upstream release
+- the `-nix.N` revision increments for packaging-only changes
+
+A scheduled workflow checks upstream every 12 hours and opens an update PR automatically.
+
 ## References
 
 - [Vize repository](https://github.com/ubugeeei/vize)
+- [Vize binary releases](https://github.com/ubugeeei-prod/vize/releases)

--- a/flake.nix
+++ b/flake.nix
@@ -8,45 +8,26 @@
   outputs =
     { self, nixpkgs }:
     let
-      version = "0.276.0";
-
-      sources = {
-        "aarch64-darwin" = {
-          asset = "vize-aarch64-apple-darwin.tar.gz";
-          hash = "sha256-JFGTaSNFAG9/W04AADtAcORkjXEdMgfWFcZ2EKqBV8s=";
-        };
-        "aarch64-linux" = {
-          asset = "vize-aarch64-unknown-linux-gnu.tar.gz";
-          hash = "sha256-AzHX6AiXgjjewpQDCNtDS9WMX1d5cT5Edud5s3ZPWrE=";
-        };
-        "x86_64-linux" = {
-          asset = "vize-x86_64-unknown-linux-gnu.tar.gz";
-          hash = "sha256-T8v8kBNBcVVGghqwbSJ8Dg4xx0Xbs2y//u5NOedhwls=";
-        };
-      };
+      inherit (builtins.fromJSON (builtins.readFile ./sources.json)) version sources;
 
       supportedSystems = builtins.attrNames sources;
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      mkVize = system:
+      mkVize =
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          src = sources.${system};
-          isLinux = pkgs.stdenv.hostPlatform.isLinux;
         in
         pkgs.stdenv.mkDerivation {
           pname = "vize";
           inherit version;
 
           src = pkgs.fetchurl {
-            url = "https://github.com/ubugeeei-prod/vize/releases/download/v${version}/${src.asset}";
-            hash = src.hash;
+            url = "https://github.com/ubugeeei-prod/vize/releases/download/v${version}/${sources.${system}.asset}";
+            inherit (sources.${system}) hash;
           };
 
           sourceRoot = ".";
-
-          nativeBuildInputs = pkgs.lib.optional isLinux pkgs.autoPatchelfHook;
-          buildInputs = pkgs.lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
 
           installPhase = ''
             runHook preInstall
@@ -54,11 +35,13 @@
             runHook postInstall
           '';
 
+          nativeInstallCheckInputs = [ pkgs.versionCheckHook ];
+          doInstallCheck = true;
+
           meta = {
             description = "High-performance Vue.js toolchain in Rust";
-            homepage = "https://github.com/ubugeeei/vize";
+            homepage = "https://vizejs.dev";
             license = pkgs.lib.licenses.mit;
-            maintainers = [ ];
             mainProgram = "vize";
             platforms = supportedSystems;
             sourceProvenance = with pkgs.lib.sourceTypes; [ binaryNativeCode ];
@@ -66,30 +49,17 @@
         };
     in
     {
-      packages = forAllSystems (system:
-        let vize = mkVize system; in
-        {
-          inherit vize;
-          default = vize;
-        }
-      );
+      packages = forAllSystems (system: rec {
+        vize = mkVize system;
+        default = vize;
+      });
 
-      apps = forAllSystems (system:
-        let
-          vize = mkVize system;
-          app = {
-            type = "app";
-            program = "${vize}/bin/vize";
-            meta = {
-              description = "High-performance Vue.js toolchain in Rust";
-              mainProgram = "vize";
-            };
-          };
-        in
-        {
-          vize = app;
-          default = app;
-        }
-      );
+      overlays.default = final: prev: {
+        vize = self.packages.${prev.stdenv.hostPlatform.system}.vize;
+      };
+
+      checks = forAllSystems (system: {
+        vize = self.packages.${system}.vize;
+      });
     };
 }

--- a/sources.json
+++ b/sources.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.276.0",
+  "sources": {
+    "aarch64-darwin": {
+      "asset": "vize-aarch64-apple-darwin.tar.gz",
+      "hash": "sha256-JFGTaSNFAG9/W04AADtAcORkjXEdMgfWFcZ2EKqBV8s="
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Restrict support to `aarch64-darwin` (drop `aarch64-linux` / `x86_64-linux`), removing `autoPatchelfHook` and the Linux-only build inputs
- Move the version and per-platform hashes out of `flake.nix` into `sources.json`; the update workflow now edits JSON with `jq` / `awk` instead of running `sed` against Nix code
- Remove the `apps` output (`nix run` falls back to `packages.default`); add `overlays.default` and `checks`
- Add an install-time `--version` smoke check via `versionCheckHook`, so a broken binary fails the update PR build
- Use a fixed `update-vize` branch for update PRs so a newer release supersedes an unmerged one
- Collapse CI to a single macOS job; the job id stays `ci-complete` to satisfy the main-protection ruleset
- Add a weekly `flake.lock` update workflow
- Rewrite README with usage instructions

## Verification

- `nix flake check --print-build-logs` passes on aarch64-darwin; `versionCheckPhase` confirmed `vize 0.276.0`
- actionlint reports no issues on the touched workflows
- The `jq` / `awk` update logic was simulated locally against a fake release and produces the same `sources.json` / `CHANGELOG.md` shape as the previous `sed` implementation

## Notes

- After merging, close the stale update PR #180 (old per-version branch scheme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)